### PR TITLE
remove unused crate imports

### DIFF
--- a/examples/claim.rs
+++ b/examples/claim.rs
@@ -2,7 +2,6 @@
 #![no_std]
 
 extern crate blue_pill;
-extern crate cortex_m;
 extern crate cortex_m_rtfm as rtfm;
 
 use blue_pill::stm32f103xx::Interrupt;

--- a/examples/usart1-rx-dma.rs
+++ b/examples/usart1-rx-dma.rs
@@ -7,7 +7,6 @@
 
 extern crate blue_pill;
 extern crate cortex_m_rtfm as rtfm;
-extern crate nb;
 
 use blue_pill::Serial;
 use blue_pill::dma::{Buffer, Dma1Channel5};

--- a/examples/usart1-tx-dma.rs
+++ b/examples/usart1-tx-dma.rs
@@ -7,7 +7,6 @@
 
 extern crate blue_pill;
 extern crate cortex_m_rtfm as rtfm;
-extern crate nb;
 
 use blue_pill::Serial;
 use blue_pill::dma::{Buffer, Dma1Channel4};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,9 @@
 
 #![deny(missing_docs)]
 #![deny(warnings)]
+#![feature(const_cell_new)]
 #![feature(const_fn)]
+#![feature(const_unsafe_cell_new)]
 #![feature(get_type_id)]
 #![feature(never_type)]
 #![feature(unsize)]


### PR DESCRIPTION
such as `extern crate nb` in order to compile with
`rustc 1.22.0-nightly (744dd6c1d 2017-09-02)`