### PR TITLE
Fix PWM generation for TIM1

### DIFF
--- a/src/pwm.rs
+++ b/src/pwm.rs
@@ -127,6 +127,8 @@ impl<'a> Pwm<'a, TIM1> {
                 .cc4p()
                 .clear_bit()
         });
+        
+        tim1.bdtr.modify(|_, w| w.moe().set_bit());
 
         self._set_period(period);
 


### PR DESCRIPTION
`MOE` bit in `BDTR` register needs to be set.